### PR TITLE
feat: use low level verifier & kms api for cwt

### DIFF
--- a/cwt/cwt_test.go
+++ b/cwt/cwt_test.go
@@ -34,12 +34,15 @@ func TestParse(t *testing.T) {
 		assert.NoError(t, decodeErr)
 
 		proofChecker := NewMockProofChecker(gomock.NewController(t))
-		proofChecker.EXPECT().CheckCWTProof(gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(request checker.CheckCWTProofRequest, message *cose.Sign1Message, expectedIssuer string) error {
+		proofChecker.EXPECT().CheckCWTProof(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(request checker.CheckCWTProofRequest, expectedIssuer string, message, sign []byte) error {
 				assert.Equal(t, "AsymmetricECDSA256", request.KeyID)
 				assert.Equal(t, cose.AlgorithmES256, request.Algo)
 				assert.NotNil(t, message)
 				assert.Equal(t, "coap://as.example.com", expectedIssuer)
+				assert.NotNil(t, sign)
+				assert.NotNil(t, message)
+
 				return nil
 			})
 
@@ -53,8 +56,8 @@ func TestParse(t *testing.T) {
 		assert.NoError(t, decodeErr)
 
 		proofChecker := NewMockProofChecker(gomock.NewController(t))
-		proofChecker.EXPECT().CheckCWTProof(gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(request checker.CheckCWTProofRequest, message *cose.Sign1Message, expectedIssuer string) error {
+		proofChecker.EXPECT().CheckCWTProof(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(request checker.CheckCWTProofRequest, expectedIssuer string, message []byte, sign []byte) error {
 				return errors.New("invalid proof")
 			})
 
@@ -118,7 +121,7 @@ func TestParse(t *testing.T) {
 	})
 
 	t.Run("no algo", func(t *testing.T) {
-		assert.ErrorContains(t, cwt.CheckProof(&cose.Sign1Message{}, nil, nil),
+		assert.ErrorContains(t, cwt.CheckProof(&cose.Sign1Message{}, nil, nil, nil, nil),
 			"algorithm not found")
 	})
 
@@ -129,7 +132,7 @@ func TestParse(t *testing.T) {
 					cose.HeaderLabelAlgorithm: cose.AlgorithmES256,
 				},
 			},
-		}, nil, nil),
+		}, nil, nil, nil, nil),
 			"check cwt failure: kid header is required")
 	})
 }

--- a/cwt/interfaces.go
+++ b/cwt/interfaces.go
@@ -8,8 +8,6 @@ package cwt
 
 //go:generate mockgen -destination interfaces_mocks_test.go -package cwt_test -source=interfaces.go
 import (
-	"github.com/veraison/go-cose"
-
 	"github.com/trustbloc/vc-go/proof/checker"
 )
 
@@ -17,7 +15,8 @@ import (
 type ProofChecker interface {
 	CheckCWTProof(
 		checkCWTRequest checker.CheckCWTProofRequest,
-		msg *cose.Sign1Message,
 		expectedProofIssuer string,
+		msg []byte,
+		signature []byte,
 	) error
 }

--- a/cwt/wrappers.go
+++ b/cwt/wrappers.go
@@ -22,9 +22,10 @@ type Verifier struct {
 
 // Verify verifies CWT proof.
 func (v *Verifier) Verify(
-	proof *cose.Sign1Message,
 	keyID string,
 	algo cose.Algorithm,
+	msg []byte,
+	sign []byte,
 ) error {
 	var expectedProofIssuer string
 
@@ -38,5 +39,5 @@ func (v *Verifier) Verify(
 	return v.ProofChecker.CheckCWTProof(checker.CheckCWTProofRequest{
 		KeyID: keyID,
 		Algo:  algo,
-	}, proof, expectedProofIssuer)
+	}, expectedProofIssuer, msg, sign)
 }

--- a/cwt/wrappers_test.go
+++ b/cwt/wrappers_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"github.com/veraison/go-cose"
 
 	"github.com/trustbloc/vc-go/cwt"
 	"github.com/trustbloc/vc-go/proof/checker"
@@ -24,18 +23,15 @@ func TestWrapper(t *testing.T) {
 			ProofChecker: mockVerifier,
 		}
 
-		mockVerifier.EXPECT().CheckCWTProof(gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(
-				request checker.CheckCWTProofRequest,
-				message *cose.Sign1Message,
-				expectedProofIssuer string,
-			) error {
+		mockVerifier.EXPECT().CheckCWTProof(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(request checker.CheckCWTProofRequest, expectedProofIssuer string,
+				bytes []byte, bytes2 []byte) error {
 				assert.Equal(t, "coap://as.example.com", expectedProofIssuer)
 
 				return nil
 			})
 
-		assert.NoError(t, verifier.Verify(&cose.Sign1Message{},
-			"coap://as.example.com#AsymmetricECDSA256#321232131", 0))
+		assert.NoError(t, verifier.Verify("coap://as.example.com#AsymmetricECDSA256#321232131", 0,
+			nil, nil))
 	})
 }

--- a/proof/checker/checker_test.go
+++ b/proof/checker/checker_test.go
@@ -107,30 +107,30 @@ func TestProofChecker_CheckCWTProof(t *testing.T) {
 
 	err := testable.CheckCWTProof(checker.CheckCWTProofRequest{
 		Algo: cose.AlgorithmEd25519,
-	}, &cose.Sign1Message{}, "issuerID")
+	}, "issuerID", nil, nil)
 	require.ErrorContains(t, err, "missed kid in cwt header")
 
 	err = testable.CheckCWTProof(checker.CheckCWTProofRequest{
 		KeyID: "tid",
-	}, &cose.Sign1Message{}, "issuerID")
+	}, "issuerID", nil, nil)
 	require.ErrorContains(t, err, "missed alg in cwt header")
 
 	err = testable.CheckCWTProof(checker.CheckCWTProofRequest{
 		KeyID: "tid",
 		Algo:  1,
-	}, &cose.Sign1Message{}, "issuerID")
+	}, "issuerID", nil, nil)
 	require.ErrorContains(t, err, "invalid public key id")
 
 	err = testable.CheckCWTProof(checker.CheckCWTProofRequest{
 		KeyID: "lookupId",
 		Algo:  1,
-	}, &cose.Sign1Message{}, "issuerID")
+	}, "issuerID", nil, nil)
 	require.ErrorContains(t, err, "unsupported cwt alg:")
 
 	err = testable.CheckCWTProof(checker.CheckCWTProofRequest{
 		KeyID: "lookupId",
 		Algo:  cose.AlgorithmEd25519,
-	}, &cose.Sign1Message{}, "issuerID")
+	}, "issuerID", nil, nil)
 	require.ErrorContains(t, err, "can't verifiy with \"test\" verification method")
 }
 
@@ -144,8 +144,7 @@ func TestProofCheckerIssuerCwt(t *testing.T) {
 			KeyID: "tid",
 			Algo:  cose.AlgorithmEd25519,
 		},
-		&cose.Sign1Message{},
-		"abcd")
+		"abcd", nil, nil)
 
 	require.ErrorContains(t, err, `invalid public key id: invalid issuer. expected "awesome" got "abcd"`)
 }

--- a/proof/testsupport/commontest/commontest.go
+++ b/proof/testsupport/commontest/commontest.go
@@ -253,7 +253,7 @@ func TestAllCWTSignersVerifiers(t *testing.T) {
 			msg.Signature = signed
 
 			assert.NotNil(t, signed)
-			assert.NoError(t, cwt.CheckProof(msg, proofChecker, nil))
+			assert.NoError(t, cwt.CheckProof(msg, proofChecker, nil, signData, msg.Signature))
 		})
 	}
 }


### PR DESCRIPTION
Use low-level kms & verifier api to verify CWT signature instead of dependency on cose library to simplify work with keys