### PR TITLE
feat: handle same credential type with same descriptor id

### DIFF
--- a/presexch/api.go
+++ b/presexch/api.go
@@ -292,6 +292,7 @@ func (pd *PresentationDefinition) evalSubmissionRequirements(matched []*MatchVal
 
 	for i := range descriptorIDs {
 		found := false
+
 		for _, m := range matched {
 			if m.DescriptorID == i {
 				found = true

--- a/presexch/example_v1_test.go
+++ b/presexch/example_v1_test.go
@@ -1682,10 +1682,13 @@ func ExamplePresentationDefinition_Match() {
 	}
 
 	for _, descriptor := range verifierDefinitions.InputDescriptors {
-		receivedCred := matched[descriptor.ID]
-		fmt.Printf(
-			"verifier received the '%s' credential for the input descriptor id '%s'\n",
-			receivedCred.Credential.Contents().Context[1], descriptor.ID)
+		for _, match := range matched {
+			if match.DescriptorID == descriptor.ID {
+				fmt.Printf(
+					"verifier received the '%s' credential for the input descriptor id '%s'\n",
+					match.Credential.Contents().Context[1], descriptor.ID)
+			}
+		}
 	}
 
 	// Output:


### PR DESCRIPTION
When we present the same type of credential twice, they can match to a single descriptor ID.
currently only 1 credential is returned, instead of correct count of credentials