### PR TITLE
fix: panic if Issued not set during jwt serialization

### DIFF
--- a/verifiable/credential.go
+++ b/verifiable/credential.go
@@ -1937,6 +1937,34 @@ func (vc *Credential) WithModifiedID(id string) *Credential {
 	}
 }
 
+// WithModifiedIssued creates new credential with modified issued time and without proofs as they become invalid.
+func (vc *Credential) WithModifiedIssued(wrapper *util.TimeWrapper) *Credential {
+	newCredJSON := copyCredentialJSONWithoutProofs(vc.credentialJSON)
+	newContents := vc.Contents()
+
+	newContents.Issued = wrapper
+	newCredJSON[jsonFldIssued] = serializeTime(wrapper)
+
+	return &Credential{
+		credentialJSON:     newCredJSON,
+		credentialContents: newContents,
+	}
+}
+
+// WithModifiedExpired creates new credential with modified expired time and without proofs as they become invalid.
+func (vc *Credential) WithModifiedExpired(wrapper *util.TimeWrapper) *Credential {
+	newCredJSON := copyCredentialJSONWithoutProofs(vc.credentialJSON)
+	newContents := vc.Contents()
+
+	newContents.Expired = wrapper
+	newCredJSON[jsonFldExpired] = serializeTime(wrapper)
+
+	return &Credential{
+		credentialJSON:     newCredJSON,
+		credentialContents: newContents,
+	}
+}
+
 // WithModifiedContext creates new credential with modified context and without proofs as they become invalid.
 func (vc *Credential) WithModifiedContext(context []string) *Credential {
 	newCredJSON := copyCredentialJSONWithoutProofs(vc.credentialJSON)

--- a/verifiable/credential_jwt.go
+++ b/verifiable/credential_jwt.go
@@ -90,10 +90,9 @@ func newJWTCredClaims(vc *Credential, minimizeVC bool) (*JWTCredClaims, error) {
 
 	// currently jwt encoding supports only single subject (by the spec)
 	jwtClaims := &jwt.Claims{
-		Issuer:    vcc.Issuer.ID,                           // iss
-		NotBefore: josejwt.NewNumericDate(vcc.Issued.Time), // nbf
-		ID:        vcc.ID,                                  // jti
-		Subject:   subjectID,                               // sub
+		Issuer:  vcc.Issuer.ID, // iss
+		ID:      vcc.ID,        // jti
+		Subject: subjectID,     // sub
 	}
 
 	if vcc.Expired != nil {
@@ -102,6 +101,7 @@ func newJWTCredClaims(vc *Credential, minimizeVC bool) (*JWTCredClaims, error) {
 
 	if vcc.Issued != nil {
 		jwtClaims.IssuedAt = josejwt.NewNumericDate(vcc.Issued.Time)
+		jwtClaims.NotBefore = josejwt.NewNumericDate(vcc.Issued.Time)
 	}
 
 	credentialJSONCopy := jsonutil.ShallowCopyObj(vc.credentialJSON)

--- a/verifiable/credential_test.go
+++ b/verifiable/credential_test.go
@@ -23,7 +23,6 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/trustbloc/vc-go/proof/testsupport"
-
 	jsonutil "github.com/trustbloc/vc-go/util/json"
 )
 
@@ -2219,6 +2218,9 @@ func TestCredential_WithModified(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
+	now := time.Now()
+	expired := now.Add(time.Hour)
+
 	cred = cred.
 		WithModifiedID("newID").
 		WithModifiedSubject([]Subject{{ID: "newID"}}).
@@ -2227,7 +2229,9 @@ func TestCredential_WithModified(t *testing.T) {
 		WithModifiedStatus(&TypedID{
 			ID:   "newID",
 			Type: "newType",
-		})
+		}).
+		WithModifiedExpired(afgotime.NewTime(expired)).
+		WithModifiedIssued(afgotime.NewTime(now))
 
 	require.Equal(t, "newID", cred.Contents().ID)
 	require.Equal(t, "newID", cred.Contents().Subject[0].ID)
@@ -2235,6 +2239,8 @@ func TestCredential_WithModified(t *testing.T) {
 	require.Equal(t, []string{"newContext"}, cred.Contents().Context)
 	require.Equal(t, "newID", cred.Contents().Status.ID)
 	require.Equal(t, "newType", cred.Contents().Status.Type)
+	require.EqualValues(t, now, cred.Contents().Issued.Time)
+	require.EqualValues(t, expired, cred.Contents().Expired.Time)
 
 	cred = cred.
 		WithModifiedID("").


### PR DESCRIPTION
fix: panic if Issued not set during jwt serialization.
Issued can be nil in some cases.

Also added two methods to extend Credential API with  WithModifiedExpired WithModifiedIssued