### PR TITLE
fix: SD-JWT V5 create presentation for arrays

### DIFF
--- a/presexch/definition.go
+++ b/presexch/definition.go
@@ -1130,6 +1130,7 @@ func getLimitedDisclosures(constraints *Constraints, displaySrc []byte, credenti
 
 				limitedDisclosures = append(limitedDisclosures, disVal)
 			}
+			// cmd
 
 			for _, dc := range allDisclosures {
 				if dc.Name == key {

--- a/presexch/definition.go
+++ b/presexch/definition.go
@@ -1119,7 +1119,7 @@ func getLimitedDisclosures(constraints *Constraints, displaySrc []byte, credenti
 			disclosures := credential.SDJWTDisclosures()
 			disclosuresMap := map[string]*common.DisclosureClaim{}
 			for _, dc := range disclosures {
-				disclosuresMap[dc.Disclosure] = dc
+				disclosuresMap[dc.Digest] = dc
 			}
 
 			arrayElements := ExtractArrayValuesForSDJWTV5(parentObj)

--- a/presexch/definition.go
+++ b/presexch/definition.go
@@ -1118,6 +1118,7 @@ func getLimitedDisclosures(constraints *Constraints, displaySrc []byte, credenti
 
 			disclosures := credential.SDJWTDisclosures()
 			disclosuresMap := map[string]*common.DisclosureClaim{}
+
 			for _, dc := range disclosures {
 				disclosuresMap[dc.Digest] = dc
 			}
@@ -1148,6 +1149,7 @@ func getLimitedDisclosures(constraints *Constraints, displaySrc []byte, credenti
 	return limitedDisclosures, nil
 }
 
+// ExtractArrayValuesForSDJWTV5 extracts array values for SD JWT V5.
 func ExtractArrayValuesForSDJWTV5(obj map[string]interface{}) []string {
 	var extractedValues []string
 

--- a/presexch/definition.go
+++ b/presexch/definition.go
@@ -1130,7 +1130,6 @@ func getLimitedDisclosures(constraints *Constraints, displaySrc []byte, credenti
 
 				limitedDisclosures = append(limitedDisclosures, disVal)
 			}
-			// cmd
 
 			for _, dc := range allDisclosures {
 				if dc.Name == key {
@@ -1145,6 +1144,16 @@ func getLimitedDisclosures(constraints *Constraints, displaySrc []byte, credenti
 				}
 			}
 		}
+	}
+
+	finalDisclosures := map[*common.DisclosureClaim]struct{}{}
+	for _, closure := range limitedDisclosures {
+		finalDisclosures[closure] = struct{}{}
+	}
+
+	limitedDisclosures = nil
+	for closure, _ := range finalDisclosures {
+		limitedDisclosures = append(limitedDisclosures, closure)
 	}
 
 	return limitedDisclosures, nil

--- a/presexch/definition_test.go
+++ b/presexch/definition_test.go
@@ -2361,6 +2361,36 @@ func TestPresentationDefinition_CreateVPArray(t *testing.T) {
 	})
 }
 
+func TestExtractExtraFields(t *testing.T) {
+	results := ExtractArrayValuesForSDJWTV5(map[string]interface{}{
+		"_sd": []interface{}{
+			"k1NxQSAyCCHlGw-93hxPzOFqUY4Ye7gLqLiKMkSZfHLa48Sevxr5zGHS6Yrb3arK",
+			"wu3GHwpa1pJaIv2U71-Y_9kdzjBxlZYRVOG03SIqrOMuytclBPOAU1FSlAnEgOzh",
+		},
+		"type": []interface{}{
+			map[string]interface{}{
+				"...": "mhV9Kt70m-8slbu1TgIpdr6_AWO-kG51Q2amF3w9qQyyxM-aXsTn77uxMBAnFM67",
+			},
+		},
+		"someObject": map[string]interface{}{
+			"nested": map[string]interface{}{
+				"nested2": map[string]interface{}{
+					"type": []interface{}{
+						map[string]interface{}{
+							"...": "xxx",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.EqualValues(t, []string{
+		"mhV9Kt70m-8slbu1TgIpdr6_AWO-kG51Q2amF3w9qQyyxM-aXsTn77uxMBAnFM67",
+		"xxx",
+	}, results)
+}
+
 func getTestVCWithContext(t *testing.T, issuerID string, ctx []string) *verifiable.Credential {
 	subjectJSON := map[string]interface{}{
 		"id":           uuid.New().String(),


### PR DESCRIPTION
When we prepare disclosures for SD-JWT v5 encoded arrays, we mishandle arrays. 

We need to extract valid elements in arrays.

---
Coverage report includes some extra changes from other prs.