### PR TITLE
feat: Add default schema loader option

### DIFF
--- a/verifiable/credential.go
+++ b/verifiable/credential.go
@@ -1028,6 +1028,7 @@ type credentialOpts struct {
 	disabledProofCheck   bool
 	strictValidation     bool
 	defaultSchema        string
+	defaultSchemaLoader  func(vcc *CredentialContents) string
 	disableValidation    bool
 	verifyDataIntegrity  *verifyDataIntegrityOpts
 
@@ -1055,6 +1056,13 @@ func WithCredDisableValidation() CredentialOpt {
 func WithSchema(schema string) CredentialOpt {
 	return func(opts *credentialOpts) {
 		opts.defaultSchema = schema
+	}
+}
+
+// WithDefaultSchemaLoader sets the schema loader function.
+func WithDefaultSchemaLoader(loader func(vcc *CredentialContents) string) CredentialOpt {
+	return func(opts *credentialOpts) {
+		opts.defaultSchemaLoader = loader
 	}
 }
 
@@ -1973,6 +1981,10 @@ func getSchemaLoader(vcc *CredentialContents, opts *credentialOpts) (gojsonschem
 
 	if opts.defaultSchema != "" {
 		return gojsonschema.NewStringLoader(opts.defaultSchema), nil
+	}
+
+	if opts.defaultSchemaLoader != nil {
+		return gojsonschema.NewStringLoader(opts.defaultSchemaLoader(vcc)), nil
 	}
 
 	for _, schema := range vcc.Schemas {

--- a/verifiable/credential_test.go
+++ b/verifiable/credential_test.go
@@ -179,13 +179,18 @@ func TestParseCredentialWithoutIssuanceDate(t *testing.T) {
 	})
 }
 
-func TestParseV2CredentialWithoutValidFrom(t *testing.T) {
+func TestParseV2CredentialWithoutIssuer(t *testing.T) {
 	t.Run("test creation of new Verifiable Credential with disabled issuer check", func(t *testing.T) {
-		schema := JSONSchemaLoaderV2(WithDisableRequiredField("issuer"))
-
 		vc, err := parseTestCredential(t, []byte(v2CredentialWithoutIssuer), WithDisabledProofCheck(),
 			WithStrictValidation(),
-			WithSchema(schema))
+			WithDefaultSchemaLoader(func(vcc *CredentialContents) string {
+				if IsBaseContext(vcc.Context, V2ContextURI) {
+					return JSONSchemaLoaderV2(WithDisableRequiredField("issuer"))
+				}
+
+				return JSONSchemaLoaderV1()
+			}),
+		)
 		require.NoError(t, err)
 		require.NotNil(t, vc)
 	})


### PR DESCRIPTION
Added the option, WithDefaultSchemaLoader, which allows a caller to load the schema given a set of contexts.