### PR TITLE
feat: Add support for multiple-status entries in VC

### DIFF
--- a/presexch/definition_test.go
+++ b/presexch/definition_test.go
@@ -3569,7 +3569,7 @@ type credentialProto struct {
 	Issuer         *verifiable.Issuer
 	Issued         *utiltime.TimeWrapper
 	Expired        *utiltime.TimeWrapper
-	Status         *verifiable.TypedID
+	Status         []*verifiable.TypedID
 	Schemas        []verifiable.TypedID
 	Evidence       verifiable.Evidence
 	TermsOfUse     []verifiable.TypedID

--- a/status/api/api.go
+++ b/status/api/api.go
@@ -16,6 +16,7 @@ type Validator interface {
 	ValidateStatus(vcStatus *verifiable.TypedID) error
 	GetStatusVCURI(vcStatus *verifiable.TypedID) (string, error)
 	GetStatusListIndex(vcStatus *verifiable.TypedID) (int, error)
+	GetStatusPurpose(vcStatus *verifiable.TypedID) (string, error)
 }
 
 // ValidatorGetter provides the matching Validator for a given credential status type.

--- a/status/status.go
+++ b/status/status.go
@@ -18,8 +18,17 @@ import (
 )
 
 const (
-	// RevokedMessage is the Client.VerifyStatus error message when the given verifiable.Credential is revoked.
-	RevokedMessage = "revoked"
+	// StatusPurposeRevocation is the purpose of the status list entry for revocation.
+	StatusPurposeRevocation = "revocation"
+	// StatusPurposeSuspension is the purpose of the status list entry for suspension.
+	StatusPurposeSuspension = "suspension"
+)
+
+var (
+	// ErrRevoked is the Client.VerifyStatus error when the given verifiable.Credential is revoked.
+	ErrRevoked = errors.New("revoked")
+	// ErrSuspended is the Client.VerifyStatus error when the given verifiable.Credential is suspended.
+	ErrSuspended = errors.New("suspended")
 )
 
 // Client verifies revocation status for Verifiable Credentials.
@@ -28,31 +37,45 @@ type Client struct {
 	Resolver        api.StatusListVCURIResolver
 }
 
-// VerifyStatus verifies the revocation status on the given Verifiable Credential, returning the errorstring "revoked"
-// if the given credential's status is revoked, nil if the credential is not revoked, and a different error if
-// verification fails.
+// VerifyStatus verifies the revocation status on the given Verifiable Credential, returning the errorstring:
+// - "revoked" if the given credential's status is revoked
+// - "suspended" if the given credential's status is suspended
+// - nil if the credential is not revoked or suspended, and a different error if verification fails.
 func (c *Client) VerifyStatus(credential *verifiable.Credential) error { //nolint:gocyclo
 	contents := credential.Contents()
-	if contents.Status == nil {
+	if len(contents.Status) == 0 {
 		return errors.New("vc missing status list field")
 	}
 
-	validator, err := c.ValidatorGetter(contents.Status.Type)
+	for _, status := range contents.Status {
+		if err := c.verifyStatus(credential, status); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) verifyStatus( //nolint:gocyclo,funlen
+	credential *verifiable.Credential,
+	status *verifiable.TypedID,
+) error {
+	validator, err := c.ValidatorGetter(status.Type)
 	if err != nil {
 		return err
 	}
 
-	err = validator.ValidateStatus(contents.Status)
+	err = validator.ValidateStatus(status)
 	if err != nil {
 		return err
 	}
 
-	statusListIndex, err := validator.GetStatusListIndex(contents.Status)
+	statusListIndex, err := validator.GetStatusListIndex(status)
 	if err != nil {
 		return err
 	}
 
-	statusVCURL, err := validator.GetStatusVCURI(contents.Status)
+	statusVCURL, err := validator.GetStatusVCURI(status)
 	if err != nil {
 		return err
 	}
@@ -63,7 +86,8 @@ func (c *Client) VerifyStatus(credential *verifiable.Credential) error { //nolin
 	}
 
 	statusListVCC := statusListVC.Contents()
-	if statusListVCC.Issuer == nil || contents.Issuer == nil || statusListVCC.Issuer.ID != contents.Issuer.ID {
+	if statusListVCC.Issuer == nil || credential.Contents().Issuer == nil ||
+		statusListVCC.Issuer.ID != credential.Contents().Issuer.ID {
 		return errors.New("issuer of the credential does not match status list vc issuer")
 	}
 
@@ -85,7 +109,19 @@ func (c *Client) VerifyStatus(credential *verifiable.Credential) error { //nolin
 	}
 
 	if bitSet {
-		return errors.New(RevokedMessage)
+		purpose, err := validator.GetStatusPurpose(status)
+		if err != nil {
+			return err
+		}
+
+		switch purpose {
+		case StatusPurposeRevocation:
+			return ErrRevoked
+		case StatusPurposeSuspension:
+			return ErrSuspended
+		default:
+			return fmt.Errorf("unsupported status purpose: %s", purpose)
+		}
 	}
 
 	return nil

--- a/status/validator/statuslist2021/statuslist2021.go
+++ b/status/validator/statuslist2021/statuslist2021.go
@@ -92,3 +92,13 @@ func (v *Validator) GetStatusListIndex(vcStatus *verifiable.TypedID) (int, error
 
 	return idx, nil
 }
+
+// GetStatusPurpose returns the purpose of the status list. For example, "revocation", "suspension".
+func (v *Validator) GetStatusPurpose(vcStatus *verifiable.TypedID) (string, error) {
+	statusPurpose, ok := vcStatus.CustomFields[StatusPurpose].(string)
+	if !ok {
+		return "", fmt.Errorf("%s must be a string", StatusPurpose)
+	}
+
+	return statusPurpose, nil
+}

--- a/verifiable/support_test.go
+++ b/verifiable/support_test.go
@@ -28,6 +28,9 @@ var (
 
 	//go:embed testdata/v1_credential_without_issuancedate.jsonld
 	v1CredentialWithoutIssuanceDate string //nolint:gochecknoglobals
+
+	//go:embed testdata/v2_valid_credential_multi_status.jsonld
+	v2ValidCredentialMultiStatus string //nolint:gochecknoglobals
 )
 
 var (

--- a/verifiable/testdata/v2_valid_credential_multi_status.jsonld
+++ b/verifiable/testdata/v2_valid_credential_multi_status.jsonld
@@ -11,13 +11,22 @@
     "image": "data:image/png;base64,iVBOR"
   },
   "validFrom": "2010-01-01T19:23:24Z",
-  "credentialStatus": {
-    "id": "urn:uuid:44118c22-5b7b-4d1f-8818-01ea041648e2",
-    "statusListCredential": "http://vc-rest-echo.trustbloc.local:8075/issuer/groups/f9af5dcf-23d8-490f-b8cb-d8b83afcb91a/credentials/status/5a8f8941-aeb9-4200-ae03-76556745ec41",
-    "statusListIndex": "5341",
-    "statusPurpose": "revocation",
-    "type": "BitstringStatusListEntry"
-  },
+  "credentialStatus": [
+    {
+      "id": "urn:uuid:44118c22-5b7b-4d1f-8818-01ea041648e2",
+      "statusListCredential": "http://vc-rest-echo.trustbloc.local:8075/issuer/groups/f9af5dcf-23d8-490f-b8cb-d8b83afcb91a/credentials/status/5a8f8941-aeb9-4200-ae03-76556745ec41",
+      "statusListIndex": "5341",
+      "statusPurpose": "revocation",
+      "type": "BitstringStatusListEntry"
+    },
+    {
+      "id": "urn:uuid:44118c22-5b7b-4d1f-8818-11ea021648d2",
+      "statusListCredential": "http://vc-rest-echo.trustbloc.local:8075/issuer/groups/f9af5dcf-23d8-490f-b8cb-d8b83afcb91a/credentials/status/5a8f8941-aeb9-4200-ae03-76556745ec43",
+      "statusListIndex": "1337",
+      "statusPurpose": "suspension",
+      "type": "BitstringStatusListEntry"
+    }
+  ],
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "alumniOf": {


### PR DESCRIPTION
Multiple credentialStatus entries may be added to the VC so that both revocation and suspension may be supported for the VC.